### PR TITLE
Fix for lint errors and a typo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
   },
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off'
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    '@typescript-eslint/no-explicit-any': 'off'
   }
 }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Your organization must be enrolled in the GitHub Copilot API private alpha.
 
 ## Setup instructions
 
-- Instrucions on how to authenticate are provided in the API documentation - available if you have access to the private alpha.
+- Instructions on how to authenticate are provided in the API documentation - available if you have access to the private alpha.
 - Edit the .env file in the root directory of the project and add the following variables:
 
 ```

--- a/src/components/RawDataViewer.vue
+++ b/src/components/RawDataViewer.vue
@@ -29,7 +29,7 @@
   </template>
   
   <script lang="ts">
-  import { defineComponent, ref } from 'vue';
+  import { defineComponent } from 'vue';
   import { getGitHubCopilotMetricsApi } from '../api/GitHubApi';
   import { Metrics } from '../model/MetricsData';
   


### PR DESCRIPTION
Hi 👋 . They're very minor ones, but I just noticed them while playing with the application 🙇 


### Typo

`Instrucions` to `Instructions`

### Lint Errors
#### Before

```
$ npm run lint
/xxx/copilot-metrics-viewer/src/api/GitHubApi.ts
  23:48  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/xxx/copilot-metrics-viewer/src/components/MetricsViewer.vue
  85:71  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  88:86  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  91:57  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  94:73  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/xxx/copilot-metrics-viewer/src/components/RawDataViewer.vue
  32:29  warning  'ref' is defined but never used           @typescript-eslint/no-unused-vars
  53:33  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/xxx/copilot-metrics-viewer/src/model/Language.ts
  10:21  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

/xxx/copilot-metrics-viewer/src/model/MetricsData.ts
  10:23  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  30:23  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  37:50  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ 11 problems (0 errors, 11 warnings)
```

#### After

```
$ npm run lint
DONE  No lint errors found!
```
